### PR TITLE
Add ability to save oc login status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ FROM centos
 MAINTAINER Steve Speicher <sspeiche@redhat.com>
 ADD bin/oc /bin/oc
 ADD bin/busy /bin/busy
-
+RUN mkdir /.kube
+RUN chmod 777 /.kube -r
 ENTRYPOINT ["/bin/busy"]


### PR DESCRIPTION
with this you don't get the mkdir permission denied when trying to create /.kube on the oc login process

I tested with https://hub.docker.com/r/rettori/oc/ 

not sure it is the best option, but it works :-)
